### PR TITLE
Feat calender favourites

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,1 +1,2 @@
 line-length = 250
+target-version = "py311"

--- a/backend.py
+++ b/backend.py
@@ -1,0 +1,73 @@
+from typing import List
+import logging
+from pydantic import BaseModel, Field
+import firebase_admin
+from firebase_admin import credentials
+from firebase_admin import firestore
+
+LOGGER = logging.getLogger()
+
+
+class Flag(BaseModel):
+    href: str
+    country: str = Field(alias="alt")
+
+
+class PlayerDetails(BaseModel):
+    fullName: str
+    shortName: str
+    flag: Flag
+
+
+class GuildConfig(BaseModel):
+    guild_id: int
+    track_players: List[str]
+
+
+class BackendStore:
+    """
+    Provides simple, document-based storage for Bot users.
+    """
+
+    CONFIG_COLLECTION_NAME = "guildConfigs"
+
+    def __init__(self):
+        cred = credentials.ApplicationDefault()
+
+        try:
+            firebase_admin.get_app()
+        except ValueError:
+            LOGGER.warning("Firebase default app being initialized.")
+            firebase_admin.initialize_app(cred)
+
+        self.db = firestore.client()
+
+    def get_guild_config(self, guild_id: int):
+        """Return the given guilds configuration"""
+        guild_id = str(guild_id)
+        data = self.db.collection(self.CONFIG_COLLECTION_NAME).document(guild_id).get().to_dict()
+        if not data:
+            return
+
+        return GuildConfig(**data)
+
+    def add_tracked_player(self, guild_id: int, player_name: str):
+        """Adds the selected player to the list of tracked players."""
+        # Coerce guild_id from its original integer value to a str so it can be used as a document ID
+        guild_config = self.get_guild_config(guild_id)
+        guild_id = str(guild_id)
+        if not guild_config:
+            LOGGER.info(f"Adding new guild config for {guild_id}.")
+            guild_config = GuildConfig(
+                guild_id=guild_id,
+                track_players=[player_name]
+            )
+            self.db.collection(self.CONFIG_COLLECTION_NAME).document(guild_id).set(dict(guild_config))
+            return guild_config
+        else:
+            LOGGER.info(f"Updating data for {guild_id}.")
+            if player_name not in guild_config.track_players:
+                guild_config.track_players.append(player_name)
+                self.db.collection(self.CONFIG_COLLECTION_NAME).document(guild_id).set(dict(guild_config))
+
+        return guild_config

--- a/bot.py
+++ b/bot.py
@@ -336,13 +336,13 @@ class Commands:
 
         return embeds
 
-    def add_tracked_player(self, backend: BackendStore, guild_id: int, player_name: str):
+    def add_tracked_player(self, guild_id: int, player_name: str):
         """Adds a player to be 'tracked', which filters all events to only those which
         feature them. Keeps the reported scoreboards from getting too gross, though doesn't currently
         effect calander events as we can't see the roster in advance."""
 
         try:
-            backend.add_tracked_player(guild_id, player_name)
+            self.backend.add_tracked_player(guild_id, player_name)
             return f"Added {player_name} to the list of tracked players!"
         except Exception:
             return "Failed to add player - backend failure."
@@ -394,7 +394,7 @@ async def show_upcoming_events(interaction: discord.Interaction):
 )
 async def add_tracked_player(interaction: discord.Interaction, player_name: str):
     """Displays the current and upcoming golf events, as published by ESPN."""
-    commands.add_tracked_player(backend_store, interaction.guild_id, player_name)
+    commands.add_tracked_player(interaction.guild_id, player_name)
     await interaction.response.send_message(f"{player_name} Successfully added to your tracked player list.")
 
 

--- a/bot.py
+++ b/bot.py
@@ -8,6 +8,8 @@ from dotenv import load_dotenv
 import discord
 import logging
 
+from backend import PlayerDetails, BackendStore, GuildConfig
+
 LOGGER = logging.getLogger()
 load_dotenv()
 BOT_TOKEN = os.getenv("BOT_TOKEN")
@@ -24,17 +26,6 @@ class CalenderEvent(BaseModel):
     startDate: datetime.datetime
     endDate: datetime.datetime
     event: EventLink
-
-
-class Flag(BaseModel):
-    href: str
-    country: str = Field(alias="alt")
-
-
-class PlayerDetails(BaseModel):
-    fullName: str
-    shortName: str
-    flag: Flag
 
 
 class Player(BaseModel):
@@ -201,6 +192,9 @@ class Top5ResponseEmbed:
                 value=f"{player_and_score.score} through {player_and_score.through} holes.",
                 inline=False
             )
+
+        embed.set_footer(text="Some events may be omitted based on your tracked player settings.")
+
         return embed
 
 
@@ -241,13 +235,39 @@ class CalenderResponseEmbed:
 
 class Commands:
 
-    @staticmethod
-    def get_current_events(event_name_filter: Optional[str] = None):
-        scoreboard = EspnScoreboardAPI.get_scoreboard()
-        return [x for x in scoreboard.events if text_string_compare(event_name_filter, x.name)]
+    def __init__(self, backend: Optional[BackendStore]):
+        self.backend = backend
 
-    @staticmethod
-    def get_upcoming_events() -> List[discord.Embed]:
+    def _get_guild_config(self, guild_id):
+        if self.backend:
+            return self.backend.get_guild_config(guild_id)
+        else:
+            return GuildConfig(
+                guild_id=guild_id,
+                track_players=[]
+            )
+
+    def _filter_events_by_guild_config(self, guild_id: int, events: List[RunningEvent]):
+        if not guild_id:
+            return events
+
+        guild_config = self._get_guild_config(guild_id)
+        track_players = [x.lower() for x in guild_config.track_players]
+
+        filtered_events = []
+        for event in events:
+            competition_players = [x.details.fullName.lower() for x in event.competitions[0].players]
+            if bool(set(track_players) & set(competition_players)):
+                filtered_events.append(event)
+
+        return filtered_events
+
+    def get_current_events(self, guild_id: Optional[int] = None, event_name_filter: Optional[str] = None):
+        scoreboard = EspnScoreboardAPI.get_scoreboard()
+        filtered_events = self._filter_events_by_guild_config(guild_id, scoreboard.events)
+        return [x for x in filtered_events if text_string_compare(event_name_filter, x.name)]
+
+    def get_upcoming_events(self) -> List[discord.Embed]:
         scoreboard = EspnScoreboardAPI.get_scoreboard()
         future_events = []
         current_events = []
@@ -272,8 +292,12 @@ class Commands:
 
         return embeds
 
-    def get_top_5_by_event(self, event_name_filter: Optional[str] = None) -> List[discord.Embed]:
-        events = self.get_current_events(event_name_filter)
+    def get_top_5_by_event(
+            self,
+            guild_id: Optional[int],
+            event_name_filter: Optional[str] = None
+    ) -> List[discord.Embed]:
+        events = self.get_current_events(guild_id, event_name_filter)
         top_five_by_event = {}
         embeds = []
 
@@ -312,6 +336,17 @@ class Commands:
 
         return embeds
 
+    def add_tracked_player(self, backend: BackendStore, guild_id: int, player_name: str):
+        """Adds a player to be 'tracked', which filters all events to only those which
+        feature them. Keeps the reported scoreboards from getting too gross, though doesn't currently
+        effect calander events as we can't see the roster in advance."""
+
+        try:
+            backend.add_tracked_player(guild_id, player_name)
+            return f"Added {player_name} to the list of tracked players!"
+        except Exception:
+            return "Failed to add player - backend failure."
+
 
 class BotClient(discord.Client):
     def __init__(self, intents: discord.Intents):
@@ -327,17 +362,22 @@ class BotClient(discord.Client):
             LOGGER.info("Done - Client connected.")
 
 
+backend_store = None
+if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
+    # Only enable the backend store if we've been given creds.
+    backend_store = BackendStore()
+
 intents = discord.Intents.default()
 intents.message_content = True
 client = BotClient(intents=intents)
 
-commands = Commands()
+commands = Commands(backend_store)
 
 
 @client.tree.command(name="show_leaderboards", description="Show running tournament leaderboards.")
 async def show_leaderboards(interaction: discord.Interaction):
     """Displays the running tournament leaderboards."""
-    embeds = commands.get_top_5_by_event()
+    embeds = commands.get_top_5_by_event(guild_id=interaction.guild_id)
     await interaction.response.send_message(embeds=embeds)
 
 
@@ -346,6 +386,16 @@ async def show_upcoming_events(interaction: discord.Interaction):
     """Displays the current and upcoming golf events, as published by ESPN."""
     embeds = commands.get_upcoming_events()
     await interaction.response.send_message(embeds=embeds)
+
+
+@client.tree.command(
+    name="add_tracked_player",
+    description="Add a player to be tracked, which filters the events to only those that feature them.",
+)
+async def add_tracked_player(interaction: discord.Interaction, player_name: str):
+    """Displays the current and upcoming golf events, as published by ESPN."""
+    commands.add_tracked_player(backend_store, interaction.guild_id, player_name)
+    await interaction.response.send_message(f"{player_name} Successfully added to your tracked player list.")
 
 
 if __name__ == '__main__':

--- a/bot.py
+++ b/bot.py
@@ -204,12 +204,73 @@ class Top5ResponseEmbed:
         return embed
 
 
+class CalenderResponseEmbed:
+    COLOR = 0x7FFFD4
+
+    @staticmethod
+    def get_embed(
+            league_name: str,
+            league_icon: str,
+            running_events: List[CalenderEvent],
+            upcoming_calender_events: List[CalenderEvent]
+    ):
+        embed = discord.Embed(
+            title=f"📅 Upcoming {league_name} Golf Tournaments",
+            description="The list of upcoming golf tournaments within the next 30 days.",
+            color=CalenderResponseEmbed.COLOR
+        )
+        for calender_event in running_events:
+            embed.add_field(
+                name=f"{calender_event.label}",
+                value="⛳ Currently in progress!",
+                inline=True
+            )
+
+        embed.set_thumbnail(url=league_icon)
+
+        for calender_event in upcoming_calender_events:
+            nice_date_string = calender_event.startDate.strftime("%d/%m/%Y")
+            embed.add_field(
+                name=f"{calender_event.label}",
+                value=f"Starts on {nice_date_string}.",
+                inline=True
+            )
+
+        return embed
+
+
 class Commands:
 
     @staticmethod
     def get_current_events(event_name_filter: Optional[str] = None):
         scoreboard = EspnScoreboardAPI.get_scoreboard()
         return [x for x in scoreboard.events if text_string_compare(event_name_filter, x.name)]
+
+    @staticmethod
+    def get_upcoming_events() -> List[discord.Embed]:
+        scoreboard = EspnScoreboardAPI.get_scoreboard()
+        future_events = []
+        current_events = []
+        today = datetime.datetime.today()
+        today = today.replace(tzinfo=datetime.timezone.utc)
+        embeds = []
+        for league in scoreboard.leagues:
+            for calender_event in league.calendar:
+                if calender_event.endDate > today > calender_event.startDate:
+                    current_events.append(calender_event)
+                elif today < calender_event.startDate < today + datetime.timedelta(days=30):
+                    future_events.append(calender_event)
+
+            embeds.append(
+                CalenderResponseEmbed.get_embed(
+                    league_name=league.name,
+                    league_icon=league.logos[-1].href,
+                    running_events=current_events,
+                    upcoming_calender_events=future_events
+                )
+            )
+
+        return embeds
 
     def get_top_5_by_event(self, event_name_filter: Optional[str] = None) -> List[discord.Embed]:
         events = self.get_current_events(event_name_filter)
@@ -226,7 +287,7 @@ class Commands:
                 rounds = linescores_to_rounds(player.linescores)
 
                 try:
-                    through = len(rounds.scorecards[current_round-1].holes)
+                    through = len(rounds.scorecards[current_round - 1].holes)
                 except IndexError:
                     through = 0
 
@@ -277,6 +338,13 @@ commands = Commands()
 async def show_leaderboards(interaction: discord.Interaction):
     """Displays the running tournament leaderboards."""
     embeds = commands.get_top_5_by_event()
+    await interaction.response.send_message(embeds=embeds)
+
+
+@client.tree.command(name="show_upcoming_events", description="Show the upcoming and in progress golf tournaments.")
+async def show_upcoming_events(interaction: discord.Interaction):
+    """Displays the current and upcoming golf events, as published by ESPN."""
+    embeds = commands.get_upcoming_events()
     await interaction.response.send_message(embeds=embeds)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pydantic
 pytest
 discord.py
 python-dotenv
+firebase-admin

--- a/test_backend.py
+++ b/test_backend.py
@@ -1,0 +1,30 @@
+import os
+import logging
+import pytest
+
+TEST_GUILD_ID = 12345
+TEST_PLAYER_NAME = "Rory McIlroy"
+TEST_PLAYER_NAME_2 = "Test Player"
+
+
+@pytest.fixture()
+def backend_fixture():
+    from dotenv import load_dotenv
+    load_dotenv()
+
+    if not os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
+        pytest.skip("This is an integration test and will not work without creds - skipping.")
+
+    from backend import BackendStore
+    return BackendStore()
+
+
+def test_add_tracked_player(backend_fixture):
+    from backend import LOGGER
+    LOGGER.setLevel(logging.DEBUG)
+    backend_fixture.add_tracked_player(TEST_GUILD_ID, TEST_PLAYER_NAME)
+    backend_fixture.add_tracked_player(TEST_GUILD_ID, TEST_PLAYER_NAME_2)
+
+    guild_config = backend_fixture.get_guild_config(TEST_GUILD_ID)
+
+    assert guild_config.track_players == [TEST_PLAYER_NAME, TEST_PLAYER_NAME_2]

--- a/test_bot.py
+++ b/test_bot.py
@@ -47,7 +47,7 @@ class TestCommands:
 
         # note; no mocked backend
         commands = Commands(None)
-        top5_by_event = commands.get_top_5_by_event()
+        top5_by_event = commands.get_top_5_by_event(None)
         assert len(top5_by_event[0].fields) == 5
 
     @patch('bot.requests')

--- a/test_bot.py
+++ b/test_bot.py
@@ -38,3 +38,17 @@ class TestCommands:
         commands = Commands()
         top5_by_event = commands.get_top_5_by_event()
         assert len(top5_by_event[0].fields) == 5
+
+    @patch('bot.requests')
+    def test_get_calender_events(self, mocked_requests, mocked_normal_response):
+        mocked_requests.get.return_value = mocked_normal_response
+
+        commands = Commands()
+        embeds = commands.get_upcoming_events()
+
+        assert len(embeds) == 1
+        current_field = next(x for x in embeds[0].fields if "The Open" in x.name)
+        assert current_field.value == "⛳ Currently in progress!"
+
+        future_field = next(x for x in embeds[0].fields if "3M Open" in x.name)
+        assert future_field.value == "Starts on 27/07/2023."


### PR DESCRIPTION
# New Features
<!-- Enter any added features; 1 per line. -->
 * `/show_upcoming_events`: Shows all the upcoming events in the next 30 days.
 * `/add_tracked_player`: Filters all results (that we can filter) based on these players. Prevents unknown or otherwise boring events being added.

# Changes
<!-- Enter your changes; 1 per line. -->
 * Added firestore backend.
 * Added verbiage under the leaderboard response to note that it may be limited by tracked players.

@adambaumeister 
